### PR TITLE
Add link to YouTube overivew Video

### DIFF
--- a/content/en/blog/falco-0-35-0/index.md
+++ b/content/en/blog/falco-0-35-0/index.md
@@ -21,6 +21,8 @@ In release v0.35.0,  we focused on addressing the following key features:
 - Improving plugins SDK
 - Test infra revamp
 
+To learn more check out our [overview video](https://www.youtube.com/watch?v=wGwXiYYUgAs) on YouTube. 
+
 ## Modern eBPF probe 👨‍🚀
 
 The new, modern eBPF probe was released as experimental during the 0.34.0 release cycle.  Since then we worked hard to implement all the remaining syscalls and behaviors, and now the same eBPF probe has left experimental status.


### PR DESCRIPTION
I added a link to the 0.35 overview video under TL:DR

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind content

**Any specific area of the project related to this PR?**

/area blog


**What this PR does / why we need it**:

Added the link to the YouTube blog per Aizhamal's request

**Which issue(s) this PR fixes**:

N/A

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**: None
